### PR TITLE
#288 - Cannot Search Nodes Using Timefield Fixer

### DIFF
--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -1,6 +1,8 @@
 # CHANGELOG for 0.x
 This changelog references the relevant changes done in 0.x versions.
 
+## v0.3.1
+* (patch) issue #288: cannot search nodes using any time field
 
 ## v0.3.0
 __BREAKING CHANGES__

--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -2,7 +2,7 @@
 This changelog references the relevant changes done in 0.x versions.
 
 ## v0.3.1
-* (patch) issue #288: cannot search nodes using any time field
+* BUG :: Fix invalid string casting on Numbr in ElasticaQueryBuilder.
 
 ## v0.3.0
 __BREAKING CHANGES__

--- a/src/Builder/ElasticaQueryBuilder.php
+++ b/src/Builder/ElasticaQueryBuilder.php
@@ -451,7 +451,7 @@ class ElasticaQueryBuilder extends AbstractQueryBuilder
             return;
         }
 
-        $value = $this->lowerCaseTerms &&  is_string($node->getValue()) ? strtolower((string)$node->getValue()) : $node->getValue();
+        $value = $this->lowerCaseTerms && !$node instanceof Numbr ? strtolower((string)$node->getValue()) : $node->getValue();
         $fieldName = $this->inField() ? $field->getName() : $this->defaultFieldName;
 
         if ($this->inField() && !$this->inSubquery()) {

--- a/src/Builder/ElasticaQueryBuilder.php
+++ b/src/Builder/ElasticaQueryBuilder.php
@@ -451,7 +451,7 @@ class ElasticaQueryBuilder extends AbstractQueryBuilder
             return;
         }
 
-        $value = $this->lowerCaseTerms ? strtolower((string)$node->getValue()) : $node->getValue();
+        $value = $this->lowerCaseTerms &&  is_string($node->getValue()) ? strtolower((string)$node->getValue()) : $node->getValue();
         $fieldName = $this->inField() ? $field->getName() : $this->defaultFieldName;
 
         if ($this->inField() && !$this->inSubquery()) {


### PR DESCRIPTION
The bug is caused by casting the value to string when it is a number. ElasticSearch expects a type of long and value is reformatted to some exponential format like this "1.5666E.. " This happens during the construction of query for ElasticSearch. Current solution is to ensure that string casting only happens on instance of Numbr class.